### PR TITLE
Add test case for metadata query and github actions to run tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22.5"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,11 +3,7 @@
 
 name: Go
 
-on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+on: [push]
 
 jobs:
   build:

--- a/examples/shakespeare_quotes.md
+++ b/examples/shakespeare_quotes.md
@@ -1,0 +1,5 @@
+---
+author: Shakespeare
+---
+
+The fool doth think he is wise, but the wise man knows himself to be a fool.

--- a/main_test.go
+++ b/main_test.go
@@ -4,8 +4,6 @@ import (
     "testing"
 )
 
-// TestHelloName calls greetings.Hello with a name, checking
-// for a valid return value.
 func TestMetadataQuery(t *testing.T) {
     query := "LIST FROM \"examples/\" WHERE [author] IS Shakespeare"
     expectedOutput := "- shakespeare_quotes.md" 

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 func TestMetadataQuery(t *testing.T) {
     query := "LIST FROM \"examples/\" WHERE [author] IS Shakespeare"
     expectedOutput := "- shakespeare_quotes.md" 
-    msg, _ := executeQuery(query, true)
+    msg, _ := executeQuery(query, false)
     if msg != expectedOutput {
       t.Error("\n" + query + "\nis expected to output:\n" + expectedOutput + "\n Got \n" + msg)
     }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+    "testing"
+)
+
+// TestHelloName calls greetings.Hello with a name, checking
+// for a valid return value.
+func TestMetadataQuery(t *testing.T) {
+    query := "LIST FROM \"examples/\" WHERE [author] IS Shakespeare"
+    expectedOutput := "- shakespeare_quotes.md" 
+    msg, _ := executeQuery(query, true)
+    if msg != expectedOutput {
+      t.Error("\n" + query + "\nis expected to output:\n" + expectedOutput + "\n Got \n" + msg)
+    }
+}


### PR DESCRIPTION
This PR sets up github actions to build and test this project.

It also adds a test for the failing test case mentioned in my issue #4 

It seems that the github actions won't run in your repo until this goes to master, but you can see the runs here:
https://github.com/anisjonischkeit/dynomark/pull/1
https://github.com/anisjonischkeit/dynomark/actions/runs/14547924263/job/40815699107
```
Run go test -v ./...
=== RUN   TestMetadataQuery
    main_test.go:1[4](https://github.com/anisjonischkeit/dynomark/actions/runs/14547924263/job/40815699107#step:5:5): 
        LIST FROM "examples/" WHERE [author] IS Shakespeare
        is expected to output:
        - shakespeare_quotes.md
         Got 
        - movie_reviews.md
        - shakespeare_quotes.md
        - tasks.md
        - test.md
--- FAIL: TestMetadataQuery (0.00s)
```